### PR TITLE
users are now associated with groups

### DIFF
--- a/StudyGroupFormer/AppWindow.cpp
+++ b/StudyGroupFormer/AppWindow.cpp
@@ -75,4 +75,9 @@ void AppWindow::on_createGroup_clicked()
 
 void AppWindow::on_successful_login(){
     ui->usernameLabel->setText(getAppUser().m_username);
+    qDebug() << "User has joined the folling studygroups:";
+    foreach (const QJsonValue &value, getAppUser().m_studygroups) {
+        QJsonObject json_obj = value.toObject();
+        qDebug() << json_obj["id"].toInt() <<  json_obj["department"].toString() << json_obj["class_number"].toInt() << json_obj["date"].toString() << json_obj["time"].toString();
+        }
 };

--- a/StudyGroupFormer/HTTPInterface.cpp
+++ b/StudyGroupFormer/HTTPInterface.cpp
@@ -61,8 +61,8 @@ QJsonArray getAllGroups(){
 }
 
 //get all groups for a particular user
-QJsonObject getUserGroups(User current_user){
-    QJsonObject json_obj;
+void getUserGroups(User current_user){
+   QJsonArray json_array;
     // create custom temporary event loop on stack
     QEventLoop eventLoop;
 
@@ -78,7 +78,7 @@ QJsonObject getUserGroups(User current_user){
     QObject::connect(&mgr, SIGNAL(finished(QNetworkReply*)), &eventLoop, SLOT(quit()));
 
     // the HTTP request
-    QNetworkRequest req( QUrl( QString("https://studygroupformer.herokuapp.com/mygroups") ) );
+    QNetworkRequest req( QUrl( QString("http://localhost:3000/mygroups") ) );
     req.setHeader(QNetworkRequest::ContentTypeHeader,"application/x-www-form-urlencoded");
     QNetworkReply *reply = mgr.post(req, headerData);
     eventLoop.exec(); // blocks stack until "finished()" has been called
@@ -88,18 +88,23 @@ QJsonObject getUserGroups(User current_user){
         QString strReply = (QString)reply->readAll();
 
         //parse json
-        qDebug() << "Response:" << strReply;
+
         QJsonDocument jsonResponse = QJsonDocument::fromJson(strReply.toUtf8());
-         json_obj = jsonResponse.object();
-       /* json_array = jsonResponse.array();
-        foreach (const QJsonValue &value, json_array) {
+         json_array = jsonResponse.array();
+
+
+
+
+        AppUser.updateGroups(json_array);
+
+        foreach (const QJsonValue &value, current_user.m_studygroups) {
             QJsonObject json_obj = value.toObject();
-            qDebug() << json_obj["id"].toInt() <<  json_obj["department"].toString() << json_obj["class_number"].toInt() << json_obj["date"].toString() << json_obj["time"].toString();
+            qDebug() << "ALHFDLs"<<json_obj["id"].toInt() <<  json_obj["department"].toString() << json_obj["class_number"].toInt() << json_obj["date"].toString() << json_obj["time"].toString();
 
+        }
 
-        }*/
         delete reply;
-        return json_obj;
+
 
     }
     else{
@@ -107,7 +112,7 @@ QJsonObject getUserGroups(User current_user){
         qDebug() << "Failure" <<reply->errorString();
         delete reply;
     }
-    return json_obj;
+
 }
 
 
@@ -221,12 +226,13 @@ bool postLogin(QString email, QString password){
             qDebug() << "Login Success";
             QJsonDocument jsonResponse = QJsonDocument::fromJson(strReply.toUtf8());
             QJsonObject json_obj = jsonResponse.object();
-             qDebug() << json_obj;
+            // qDebug() << json_obj;
 
 
              //define current user object here
              AppUser.updateUser(json_obj["Firstname"], json_obj["Lastname"], json_obj["Username"], json_obj["email"]);
-            qDebug() << AppUser.m_firstname;
+             //AppUser.updateGroups(getUserGroups(AppUser));
+
 
              delete reply;
              return true;

--- a/StudyGroupFormer/HTTPInterface.cpp
+++ b/StudyGroupFormer/HTTPInterface.cpp
@@ -70,7 +70,7 @@ void getUserGroups(User current_user){
     QNetworkAccessManager mgr;
     QByteArray headerData;
     QUrlQuery qu;
-    qu.addQueryItem("user[email]",current_user.m_email);
+    qu.addQueryItem("user[email]",current_user.m_email); //pass in the user email
     headerData.append(qu.toString());
 
 
@@ -78,7 +78,7 @@ void getUserGroups(User current_user){
     QObject::connect(&mgr, SIGNAL(finished(QNetworkReply*)), &eventLoop, SLOT(quit()));
 
     // the HTTP request
-    QNetworkRequest req( QUrl( QString("http://localhost:3000/mygroups") ) );
+    QNetworkRequest req( QUrl( QString("https://studygroupformer.herokuapp.com/mygroups") ) );
     req.setHeader(QNetworkRequest::ContentTypeHeader,"application/x-www-form-urlencoded");
     QNetworkReply *reply = mgr.post(req, headerData);
     eventLoop.exec(); // blocks stack until "finished()" has been called
@@ -96,13 +96,6 @@ void getUserGroups(User current_user){
 
 
         AppUser.updateGroups(json_array);
-
-        foreach (const QJsonValue &value, current_user.m_studygroups) {
-            QJsonObject json_obj = value.toObject();
-            qDebug() << "ALHFDLs"<<json_obj["id"].toInt() <<  json_obj["department"].toString() << json_obj["class_number"].toInt() << json_obj["date"].toString() << json_obj["time"].toString();
-
-        }
-
         delete reply;
 
 
@@ -230,7 +223,7 @@ bool postLogin(QString email, QString password){
 
 
              //define current user object here
-             AppUser.updateUser(json_obj["Firstname"], json_obj["Lastname"], json_obj["Username"], json_obj["email"]);
+             AppUser.updateUser(json_obj["Firstname"], json_obj["Lastname"], json_obj["Username"], json_obj["email"], json_obj["id"]);
              //AppUser.updateGroups(getUserGroups(AppUser));
 
 

--- a/StudyGroupFormer/HTTPInterface.h
+++ b/StudyGroupFormer/HTTPInterface.h
@@ -20,7 +20,7 @@
 
 
 QJsonArray getAllGroups();
-QJsonObject getUserGroups(User current_user);
+void getUserGroups(User current_user);
 void postCreateGroup(QString department, QString class_num, QString date, QString time);
 void postCreateUser(QString email, QString password, QString firstname, QString lastname, QString username);
 bool postLogin(QString email, QString password);

--- a/StudyGroupFormer/HTTPInterface.h
+++ b/StudyGroupFormer/HTTPInterface.h
@@ -20,6 +20,7 @@
 
 
 QJsonArray getAllGroups();
+QJsonObject getUserGroups(User current_user);
 void postCreateGroup(QString department, QString class_num, QString date, QString time);
 void postCreateUser(QString email, QString password, QString firstname, QString lastname, QString username);
 bool postLogin(QString email, QString password);

--- a/StudyGroupFormer/LoginWindow.cpp
+++ b/StudyGroupFormer/LoginWindow.cpp
@@ -36,9 +36,14 @@ void LoginWindow::login(){
     if(postLogin(uname, pass)){
 
 
-        //debug output
+        //set user groups with User object
         getUserGroups(getAppUser());
-       getAllGroups();
+
+        //debug output
+        getAllGroups();
+
+
+
 
 
       //hide window

--- a/StudyGroupFormer/LoginWindow.cpp
+++ b/StudyGroupFormer/LoginWindow.cpp
@@ -37,7 +37,9 @@ void LoginWindow::login(){
 
 
         //debug output
+        getUserGroups(getAppUser());
        getAllGroups();
+
 
       //hide window
        hide();

--- a/StudyGroupFormer/LoginWindow.h
+++ b/StudyGroupFormer/LoginWindow.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include "CreateUser.h"
+#include  "User.h"
 
 namespace Ui {
 class LoginWindow;

--- a/StudyGroupFormer/User.cpp
+++ b/StudyGroupFormer/User.cpp
@@ -7,10 +7,11 @@ User::User(){
     m_username = "null";
 }
 
-User::User(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username){
+User::User(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username, QJsonArray groups){
     m_firstname = first.toString();
     m_lastname = last.toString();
     m_username = username.toString();
+    m_studygroups = groups;
 
 }
 
@@ -22,5 +23,7 @@ void User::updateUser(QJsonValueRef first, QJsonValueRef last, QJsonValueRef use
 
 }
 
-
+void User::updateGroups(QJsonArray studygroups){
+    this->m_studygroups = studygroups;
+}
 

--- a/StudyGroupFormer/User.cpp
+++ b/StudyGroupFormer/User.cpp
@@ -15,11 +15,12 @@ User::User(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username, QJso
 
 }
 
-void User::updateUser(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username, QJsonValueRef email){
+void User::updateUser(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username, QJsonValueRef email, QJsonValueRef id){
     this->m_firstname = first.toString();
     this->m_lastname = last.toString();
     this->m_username = username.toString();
     this->m_email = email.toString();
+    this->m_id = id.toInt();
 
 }
 

--- a/StudyGroupFormer/User.cpp
+++ b/StudyGroupFormer/User.cpp
@@ -14,10 +14,11 @@ User::User(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username){
 
 }
 
-void User::updateUser(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username){
+void User::updateUser(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username, QJsonValueRef email){
     this->m_firstname = first.toString();
     this->m_lastname = last.toString();
     this->m_username = username.toString();
+    this->m_email = email.toString();
 
 }
 

--- a/StudyGroupFormer/User.h
+++ b/StudyGroupFormer/User.h
@@ -13,11 +13,12 @@ public:
     QString m_lastname;
     QString m_username;
     QString m_email;
+    int m_id;
     QJsonArray m_studygroups;
 
     User();
     User(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username, QJsonArray groups);
-    void updateUser(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username, QJsonValueRef email);
+    void updateUser(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username, QJsonValueRef email, QJsonValueRef id);
     void updateGroups(QJsonArray studygroups);
 
 signals:

--- a/StudyGroupFormer/User.h
+++ b/StudyGroupFormer/User.h
@@ -12,11 +12,12 @@ public:
     QString m_firstname;
     QString m_lastname;
     QString m_username;
+    QString m_email;
     QJsonArray m_studygroups;
 
     User();
     User(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username);
-    void updateUser(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username);
+    void updateUser(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username, QJsonValueRef email);
 
 
 signals:

--- a/StudyGroupFormer/User.h
+++ b/StudyGroupFormer/User.h
@@ -16,9 +16,9 @@ public:
     QJsonArray m_studygroups;
 
     User();
-    User(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username);
+    User(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username, QJsonArray groups);
     void updateUser(QJsonValueRef first, QJsonValueRef last, QJsonValueRef username, QJsonValueRef email);
-
+    void updateGroups(QJsonArray studygroups);
 
 signals:
 


### PR DESCRIPTION
new debug message on login shows the dummy data for groups associated with root@admin (this is basically what it would look like once someone joins a group)

new function in httpinterface.ccp:  getUserGroups() updates user object from user class, user class includes array of groups.

functions that associate a user to a study group will be coming later this weekend.